### PR TITLE
Added assmembly version of mxm for BGQ

### DIFF
--- a/makefile.template
+++ b/makefile.template
@@ -233,6 +233,7 @@ $(OBJDIR)/lb_setqvol.o	:$S/lb_setqvol.f;		$(F77) -c $(FL2) $< -o $@
 # MXM       ############################################################################
 $(OBJDIR)/mxm_wrapper.o	  :$S/mxm_wrapper.f;		$(F77) -c $(FL2) $< -o $@ 
 $(OBJDIR)/mxm_std.o	  :$S/mxm_std.f;		$(F77) -c $(FL4) $< -o $@
+$(OBJDIR)/mxm_bgq.o	  :$S/mxm_bgq.f;		$(F77) -c $(FL4) $< -o $@
 $(OBJDIR)/k10_mxm.o	  :$S/k10_mxm.c;		$(CC)  -c $(cFL2) $(JL) $< -o $@
 $(OBJDIR)/bg_aligned3.o	  :$S/bg_aligned3.s;		$(CC) -c $< -o $@
 $(OBJDIR)/bg_mxm3.o	  :$S/bg_mxm3.s;		$(CC) -c $< -o $@

--- a/makenek.inc
+++ b/makenek.inc
@@ -10,7 +10,8 @@ if [ "$PPLIST" == "?" ]; then
   echo "  NOTIMER   disable runtime statistics"
   echo "  MPITIMER  enable MPI runtime statistics"
   echo "  MPIIO     use MPI-IO I/O kernel (experimental)"
-  echo "  BG        enable Blue Gene optimizations (BG/L and BG/P)"
+  echo "  BGL        enable Blue Gene optimizations (BG/L and BG/P)"
+  echo "  BGQ        enable Blue Gene optimizations (BG/Q)"
   echo "  K10_MXM   use optimized MxM kernel for AMD Family 10h processors" 
   echo "  CVODE     use ODE solver from Sundials to solve for IFIELD>1 (experimental)"
   echo "  MOAB      enable MOAB/CUBIT support (experimental)"
@@ -333,11 +334,17 @@ if [ "$MXM_USER" != "" ]; then
     exit 1 
 fi
 MXM_USER="mxm_std.o blas.o"
-echo $PPLIST | grep 'BG' >/dev/null 
+echo $PPLIST | grep 'BGL' >/dev/null 
 if [ $? -eq 0 ]; then
    MXM_USER="mxm_std.o bg_aligned3.o bg_mxm44.o bg_mxm44_uneven.o bg_mxm3.o blas.o" 
    OPT_FLAGS_STD="-qarch=450 -qtune=450"
    OPT_FLAGS_MAG="-O5 -qarch=450d -qtune=450"
+fi
+echo $PPLIST | grep 'BGG' >/dev/null 
+if [ $? -eq 0 ]; then
+   MXM_USER="mxm_std.o mxm_bgq.o " 
+   OPT_FLAGS_STD="-O3"
+   OPT_FLAGS_MAG="-O3"
 fi
 echo $PPLIST | grep 'K10_MXM' >/dev/null 
 if [ $? -eq 0 ]; then

--- a/mxm_bgq.f
+++ b/mxm_bgq.f
@@ -1,0 +1,302 @@
+subroutine mxm_bgq_8(a,n1,b,n2,c,n3)
+  implicit none
+
+  integer  n1, n2, n3
+  real(8)  a(n1,n2),b(n2,n3)
+  real(8)  c(n1,n3)
+
+  integer i, j
+  vector(real(8)) av1, av2, av3, av4, av5, av6, av7, av8
+  vector(real(8)) bv1, bsv1, bsv2, bsv3, bsv4
+  vector(real(8)) bv2, bsv5, bsv6, bsv7, bsv8
+  vector(real(8)) cv
+
+  call alignx(32, a(1,1))
+  call alignx(32, b(1,1))
+  call alignx(32, c(1,1))
+
+  do i = 1, n1, 4
+    av1 = vec_ld(0,a(i,1))
+    av2 = vec_ld(0,a(i,2))
+    av3 = vec_ld(0,a(i,3))
+    av4 = vec_ld(0,a(i,4))
+    av5 = vec_ld(0,a(i,5))
+    av6 = vec_ld(0,a(i,6))
+    av7 = vec_ld(0,a(i,7))
+    av8 = vec_ld(0,a(i,8))
+
+    do j = 1, n3
+      bv1 = vec_ld(0,b(1,j))
+      bv2 = vec_ld(0,b(5,j))
+      bsv1 = vec_splat(bv1, 0)
+      bsv2 = vec_splat(bv1, 1)
+      bsv3 = vec_splat(bv1, 2)
+      bsv4 = vec_splat(bv1, 3)
+      bsv5 = vec_splat(bv2, 0)
+      bsv6 = vec_splat(bv2, 1)
+      bsv7 = vec_splat(bv2, 2)
+      bsv8 = vec_splat(bv2, 3)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+      cv =  vec_madd(av7, bsv7, cv)
+      cv =  vec_madd(av8, bsv8, cv)
+
+      call vec_st(cv, 0, c(i,j))
+    end do
+  end do
+  return
+end subroutine mxm_bgq_8
+
+subroutine mxm_bgq_16(a,n1,b,n2,c,n3)
+  implicit none
+
+  integer n1, n2, n3
+  real(8) a(n1,n2),b(n2,n3)
+  real(8) c(n1,n3)
+
+  integer i, j
+
+  vector(real(8)) av1, av2, av3, av4, av5, av6, av7, av8
+  vector(real(8)) av9, av10, av11, av12, av13, av14, av15, av16
+  vector(real(8)) bv1, bsv1, bsv2, bsv3, bsv4
+  vector(real(8)) bv2, bsv5, bsv6, bsv7, bsv8
+  vector(real(8)) bv3, bsv9, bsv10, bsv11, bsv12
+  vector(real(8)) bv4, bsv13, bsv14, bsv15, bsv16
+
+  vector(real(8)) cv
+
+  call alignx(32, a(1,1))
+  call alignx(32, b(1,1))
+  call alignx(32, c(1,1))
+
+  do i = 1, n1, 4
+    av1 = vec_ld(0,a(i,1))
+    av2 = vec_ld(0,a(i,2))
+    av3 = vec_ld(0,a(i,3))
+    av4 = vec_ld(0,a(i,4))
+    av5 = vec_ld(0,a(i,5))
+    av6 = vec_ld(0,a(i,6))
+    av7 = vec_ld(0,a(i,7))
+    av8 = vec_ld(0,a(i,8))
+    av9 = vec_ld(0,a(i,9))
+    av10 = vec_ld(0,a(i,10))
+    av11 = vec_ld(0,a(i,11))
+    av12 = vec_ld(0,a(i,12))
+    av13 = vec_ld(0,a(i,13))
+    av14 = vec_ld(0,a(i,14))
+    av15 = vec_ld(0,a(i,15))
+    av16 = vec_ld(0,a(i,16))
+
+    do j = 1, n3
+      bv1 = vec_ld(0,b(1,j))
+      bv2 = vec_ld(0,b(5,j))
+      bv3 = vec_ld(0,b(9,j))
+      bv4 = vec_ld(0,b(13,j))
+
+      bsv1 = vec_splat(bv1, 0)
+      bsv2 = vec_splat(bv1, 1)
+      bsv3 = vec_splat(bv1, 2)
+      bsv4 = vec_splat(bv1, 3)
+      bsv5 = vec_splat(bv2, 0)
+      bsv6 = vec_splat(bv2, 1)
+      bsv7 = vec_splat(bv2, 2)
+      bsv8 = vec_splat(bv2, 3)
+      bsv9 = vec_splat(bv3, 0)
+      bsv10 = vec_splat(bv3, 1)
+      bsv11 = vec_splat(bv3, 2)
+      bsv12 = vec_splat(bv3, 3)
+      bsv13 = vec_splat(bv4, 0)
+      bsv14 = vec_splat(bv4, 1)
+      bsv15 = vec_splat(bv4, 2)
+      bsv16 = vec_splat(bv4, 3)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+      cv =  vec_madd(av7, bsv7, cv)
+      cv =  vec_madd(av8, bsv8, cv)
+      cv =  vec_madd(av9, bsv9, cv)
+      cv =  vec_madd(av10, bsv10, cv)
+      cv =  vec_madd(av11, bsv11, cv)
+      cv =  vec_madd(av12, bsv12, cv)
+      cv =  vec_madd(av13, bsv13, cv)
+      cv =  vec_madd(av14, bsv14, cv)
+      cv =  vec_madd(av15, bsv15, cv)
+      cv =  vec_madd(av16, bsv16, cv)
+
+      call vec_st(cv, 0, c(i,j))
+    end do
+  end do
+  return
+end subroutine mxm_bgq_16
+
+
+subroutine mxm_bgq_6(a,n1,b,n2,c,n3)
+  implicit none
+
+  integer n1, n2, n3
+  real(8) a(n1,n2),b(n2,n3)
+  real(8) c(n1,n3)
+
+  integer i, j
+
+  vector(real(8)) av1, av2, av3, av4, av5, av6
+  vector(real(8)) bv1, bsv1, bsv2, bsv3, bsv4
+  vector(real(8)) bv2, bsv5, bsv6
+
+  vector(real(8)) cv
+
+  call alignx(32, a(1,1))
+  call alignx(32, b(1,1))
+  call alignx(32, c(1,1))
+
+  do i = 1, n1, 4
+    av1 = vec_ld(0,a(i,1))
+    av2 = vec_ld(0,a(i,2))
+    av3 = vec_ld(0,a(i,3))
+    av4 = vec_ld(0,a(i,4))
+    av5 = vec_ld(0,a(i,5))
+    av6 = vec_ld(0,a(i,6))
+
+    do j = 1, n3, 2
+      bv1 = vec_ld(0,b(1,j))
+      bv2 = vec_ld(0,b(5,j))
+
+      bsv1 = vec_splat(bv1, 0)
+      bsv2 = vec_splat(bv1, 1)
+      bsv3 = vec_splat(bv1, 2)
+      bsv4 = vec_splat(bv1, 3)
+      bsv5 = vec_splat(bv2, 0)
+      bsv6 = vec_splat(bv2, 1)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+
+      call vec_st(cv, 0, c(i,j))
+
+      bv1 = vec_ld(0,b(9,j))
+
+      bsv1 = vec_splat(bv2, 2)
+      bsv2 = vec_splat(bv2, 3)
+      bsv3 = vec_splat(bv1, 0)
+      bsv4 = vec_splat(bv1, 1)
+      bsv5 = vec_splat(bv1, 2)
+      bsv6 = vec_splat(bv1, 3)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+
+      call vec_st(cv, 0, c(i,j+1))
+    end do
+  end do
+  return
+end subroutine mxm_bgq_6
+
+subroutine mxm_bgq_10(a,n1,b,n2,c,n3)
+  implicit none
+
+  integer n1, n2, n3
+  real(8) a(n1,n2),b(n2,n3)
+  real(8) c(n1,n3)
+
+  integer i, j
+
+  vector(real(8)) av1, av2, av3, av4, av5, av6, av7, av8
+  vector(real(8)) av9, av10
+  vector(real(8)) bv1, bsv1, bsv2, bsv3, bsv4
+  vector(real(8)) bv2, bsv5, bsv6, bsv7, bsv8
+  vector(real(8)) bv3, bsv9, bsv10
+  vector(real(8)) cv
+
+  call alignx(32, a(1,1))
+  call alignx(32, b(1,1))
+  call alignx(32, c(1,1))
+
+  do i = 1, n1, 4
+    av1 = vec_ld(0,a(i,1))
+    av2 = vec_ld(0,a(i,2))
+    av3 = vec_ld(0,a(i,3))
+    av4 = vec_ld(0,a(i,4))
+    av5 = vec_ld(0,a(i,5))
+    av6 = vec_ld(0,a(i,6))
+    av7 = vec_ld(0,a(i,7))
+    av8 = vec_ld(0,a(i,8))
+    av9 = vec_ld(0,a(i,9))
+    av10 = vec_ld(0,a(i,10))
+
+    do j = 1, n3, 2
+      bv1 = vec_ld(0,b(1,j))
+      bv2 = vec_ld(0,b(5,j))
+      bv3 = vec_ld(0,b(9,j))
+
+      bsv1 = vec_splat(bv1, 0)
+      bsv2 = vec_splat(bv1, 1)
+      bsv3 = vec_splat(bv1, 2)
+      bsv4 = vec_splat(bv1, 3)
+      bsv5 = vec_splat(bv2, 0)
+      bsv6 = vec_splat(bv2, 1)
+      bsv7 = vec_splat(bv2, 2)
+      bsv8 = vec_splat(bv2, 3)
+      bsv9 = vec_splat(bv3, 0)
+      bsv10 = vec_splat(bv3, 1)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+      cv =  vec_madd(av7, bsv7, cv)
+      cv =  vec_madd(av8, bsv8, cv)
+      cv =  vec_madd(av9, bsv9, cv)
+      cv =  vec_madd(av10, bsv10, cv)
+
+      call vec_st(cv, 0, c(i,j))
+
+      bv1 = vec_ld(0,b(13,j))
+      bv2 = vec_ld(0,b(17,j))
+
+      bsv1 = vec_splat(bv3, 2)
+      bsv2 = vec_splat(bv3, 3)
+      bsv3 = vec_splat(bv1, 0)
+      bsv4 = vec_splat(bv1, 1)
+      bsv5 = vec_splat(bv1, 2)
+      bsv6 = vec_splat(bv1, 3)
+      bsv7 = vec_splat(bv2, 0)
+      bsv8 = vec_splat(bv2, 1)
+      bsv9 = vec_splat(bv2, 2)
+      bsv10 = vec_splat(bv2, 3)
+
+      cv =  vec_mul(av1, bsv1)
+      cv =  vec_madd(av2, bsv2, cv)
+      cv =  vec_madd(av3, bsv3, cv)
+      cv =  vec_madd(av4, bsv4, cv)
+      cv =  vec_madd(av5, bsv5, cv)
+      cv =  vec_madd(av6, bsv6, cv)
+      cv =  vec_madd(av7, bsv7, cv)
+      cv =  vec_madd(av8, bsv8, cv)
+      cv =  vec_madd(av9, bsv9, cv)
+      cv =  vec_madd(av10, bsv10, cv)
+
+      call vec_st(cv, 0, c(i,j+1))
+    end do
+  end do
+  return
+end subroutine mxm_bgq_10
+

--- a/mxm_wrapper.f
+++ b/mxm_wrapper.f
@@ -12,6 +12,8 @@ c
       integer aligned
       integer K10_mxm
 
+      integer(8) tt
+
 #ifndef NOTIMER
       if (isclld.eq.0) then
           isclld=1
@@ -23,6 +25,43 @@ c
       dct(myrout) = dct(myrout) + (isbcnt)
       ncall(myrout) = ncall(myrout) + 1
       dcount      =      dcount + (isbcnt)
+#endif
+
+
+#ifdef BGQ
+      if (n2 == 8 .and. mod(n1,4) == 0 &
+c        .and. MOD(LOC(a),tt)==0 & 
+c        .and. MOD(LOC(b),tt)==0 & 
+c        .and. MOD(LOC(c),tt)==0 & 
+        ) then
+        call mxm_bgq_8(a, n1, b, n2, c, n3)  
+        return
+      endif
+      if (n2 == 16 .and. mod(n1,4) == 0 &
+c        .and. MOD(LOC(a),tt)==0 & 
+c        .and. MOD(LOC(b),tt)==0 & 
+c        .and. MOD(LOC(c),tt)==0 & 
+         ) then
+        call mxm_bgq_16(a, n1, b, n2, c, n3)  
+        return
+      endif
+      tt = 32
+      if (n2 == 10 .and. mod(n1,4) == 0 .and. mod(n3,2) == 0 &
+        .and. MOD(LOC(a),tt)==0 & 
+        .and. MOD(LOC(b),tt)==0 & 
+        .and. MOD(LOC(c),tt)==0 & 
+          ) then
+        call mxm_bgq_10(a, n1, b, n2, c, n3)  
+        return
+      endif
+      if (n2 == 6 .and. mod(n1,4) == 0 .and. mod(n3,2) == 0 &
+        .and. MOD(LOC(a),tt)==0 & 
+        .and. MOD(LOC(b),tt)==0 & 
+        .and. MOD(LOC(c),tt)==0 & 
+       ) then
+        call mxm_bgq_6(a, n1, b, n2, c, n3)  
+        return
+      endif
 #endif
 
 #ifdef BLAS_MXM


### PR DESCRIPTION
PPLIST now expects BGL instead of BG to build for BG/L and BG/P.
This was to avoid grep matching BG to BGQ.

mxm_wrapper intercepts mxm if mod(n1,4) == 0 and n2 = {6,8,10,12,16}.